### PR TITLE
Ensure that we enable root login over ssh as needed:

### DIFF
--- a/pc-installdialog
+++ b/pc-installdialog
@@ -1055,6 +1055,11 @@ gen_pc-sysinstall_cfg()
      else
        echo "runCommand=sysrc -f /etc/rc.conf sshd_enable=\"YES\"" >> ${CFGFILE}
      fi
+     grep -q "userName=" ${CFGFILE}
+     if [ $? -ne 0 ] ; then
+       #No user created  - make sure we enable root access over SSH too
+       echo 'runCommand=echo "PermitRootLogin yes" >> /etc/ssh/sshd_config' >> ${CFGFILE}
+     fi
    fi
 
    # Check for any post-install commands


### PR DESCRIPTION
Specifically, if sshd is enabled at install, but no users are created, then we need to enable root access over ssh.